### PR TITLE
added python-tk dependency for latest python formula.

### DIFF
--- a/flatcam-beta.rb
+++ b/flatcam-beta.rb
@@ -10,6 +10,7 @@ class FlatcamBeta < Formula
   depends_on "geos"
   depends_on "pyqt"
   depends_on "python"
+  depends_on "python-tk"
   depends_on "spatialindex"
 
   def install

--- a/flatcam.rb
+++ b/flatcam.rb
@@ -12,6 +12,7 @@ class Flatcam < Formula
   depends_on "geos"
   depends_on "pkg-config"
   depends_on "python"
+  depends_on "python-tk"
   depends_on "spatialindex"
   # pip tools "numpy","matplotlib" ,"rtree", "scipy", "shapely","simplejson" ,"svg.path"
   resource "Cycler" do


### PR DESCRIPTION
ref #10 

tkinter for python in homebrew is now in separated formula `python-tk`.

https://github.com/Homebrew/homebrew-core/commit/80412c280721d4a904e3492635f24c98d173dc9d#diff-38ae209ebc6d2954d5532ae8c3e6e579dc77a7d3002bed515fa930d6ea528139

This pr solves missing dependency.