### PR TITLE
flatcam-beta: enable HEAD-Option

### DIFF
--- a/flatcam-beta.rb
+++ b/flatcam-beta.rb
@@ -3,6 +3,7 @@ class FlatcamBeta < Formula
   desc "2D Computer-Aided PCB Manufacturing(Beta)"
   homepage "http://flatcam.org/"
   url "https://bitbucket.org/jpcgt/flatcam.git", branch: "Beta", revision: "8f88fb27497011ea6d749ff8db91fd5c168b87a5"
+  head "https://bitbucket.org/jpcgt/flatcam.git", :branch => "Beta"
   version "8.9.9"
   depends_on "pkg-config" => :build
   depends_on "freetype"


### PR DESCRIPTION
According to https://docs.brew.sh/Formula-Cookbook#unstable-versions-head this should make it possible to install the current "Beta"-HEAD with `brew install -HEAD flatcam-beta`.

There have been a lot of bugfixes since the last release 8.9.9.

Any comments or ideas?