### PR TITLE
updated 8.9.94 with several patches

### DIFF
--- a/flatcam-beta.rb
+++ b/flatcam-beta.rb
@@ -2,8 +2,8 @@ class FlatcamBeta < Formula
   include Language::Python::Virtualenv
   desc "2D Computer-Aided PCB Manufacturing(Beta)"
   homepage "http://flatcam.org/"
-  url "https://bitbucket.org/jpcgt/flatcam.git", branch: "Beta", revision: "8f88fb27497011ea6d749ff8db91fd5c168b87a5"
-  version "8.9.9"
+  url "https://bitbucket.org/jpcgt/flatcam.git", branch: "Beta", revision: "f04d8be50fb57a489f7f7aa714ecf78d0dd266a6"
+  version "8.9.94"
   depends_on "pkg-config" => :build
   depends_on "freetype"
   depends_on "gdal"
@@ -16,6 +16,7 @@ class FlatcamBeta < Formula
   def install
     virtualenv_create(libexec, "python3")
     inreplace "FlatCAM.py", "import sys", "#!#{libexec}/bin/python3\nimport sys"
+    inreplace "requirements.txt", "vispy", "vispy==0.7" # patch for fixing vispy version
     system libexec/"bin/pip", "install", "descartes" # missing dependency
     system libexec/"bin/pip", "install", "-r", "requirements.txt"
     libexec.install Dir["*.py", "appCommon", "appEditors", "appGUI", "appObjects", "appParsers", "appTools", "assets", "config",\


### PR DESCRIPTION
Regarding this issue.

https://gist.github.com/natevw/3e6fc929aff358b38c0a#gistcomment-3945465

Bumped the version to 8.9.94: 

https://bitbucket.org/jpcgt/flatcam/commits/f04d8be50fb57a489f7f7aa714ecf78d0dd266a6

Also, another `inreplace` has been added to fix vispy version to 0.7.0.

Ref: https://bitbucket.org/jpcgt/flatcam/issues/538/ubuntu-fail-to-run-from-source

Confirmed working on macOS Catalina 10.15.7.