### PR TITLE
Pinning GDAL to 3.11

### DIFF
--- a/flatcam-beta.rb
+++ b/flatcam-beta.rb
@@ -20,6 +20,7 @@ class FlatcamBeta < Formula
     inreplace "requirements.txt", "vispy", "vispy==0.7.1" # patch for fixing vispy version
     inreplace "requirements.txt", "numpy>=1.16", "numpy>=1.16, <2.0"
     inreplace "requirements.txt", "shapely>=1.7.0", "shapely==1.8.5"
+    inreplace "requirements.txt", "gdal", "gdal < 3.12" # gdal 3.12 is not on brew (#38)
     system libexec/"bin/pip", "install", "descartes" # missing dependency
     system libexec/"bin/pip", "install", "-r", "requirements.txt"
     libexec.install Dir["*.py", "appCommon", "appEditors", "appGUI", "appObjects", "appParsers", "appTools", "assets", "config",\

--- a/flatcam-evo.rb
+++ b/flatcam-evo.rb
@@ -18,6 +18,7 @@ class FlatcamEvo < Formula
       venv = virtualenv_create(libexec, "python3.11", without_pip: false)
       inreplace "flatcam.py", "\nimport sys", "#!#{libexec}/bin/python3\nimport sys"
       inreplace "requirements.txt", "numpy>=1.16", "numpy>=1.16, <2.0" # fix numpy 2.x issue(#31)
+      inreplace "requirements.txt", "gdal", "gdal < 3.12" # gdal 3.12 is not on brew (#38)
       system libexec/"bin/pip", "install",
                     "--no-binary", "pillow",# fix link breakage of libpng(#27)
                     "-r", "requirements.txt"


### PR DESCRIPTION
close #38

GDAL 3.12 is not on homebrew but gdal in `requirements.txt` is not pinned, so pip install tries to install 3.12 and fails.

This PR applies patch to requirements.txt to 3.11.