### PR TITLE
fixed gdal 3.12 issue

### DIFF
--- a/flatcam-evo.rb
+++ b/flatcam-evo.rb
@@ -2,7 +2,7 @@ class FlatcamEvo < Formula
     include Language::Python::Virtualenv
     desc "2D Computer-Aided PCB Manufacturing(Beta-evo)"
     homepage "https://bitbucket.org/marius_stanciu/flatcam_beta"
-    url "https://bitbucket.org/marius_stanciu/flatcam_beta.git", branch: "Beta_8.995", revision: "1ef01840d00eaad9dbd906832911ef63c0748625"
+    url "https://bitbucket.org/marius_stanciu/flatcam_beta.git", branch: "Beta_8.995", revision: "d0a86cf4f1ac41a206b20f316d4a29f28a93bbff"
     version "8.9.95"
     depends_on "pkg-config" => :build
     depends_on "freetype"

--- a/flatcam-evo.rb
+++ b/flatcam-evo.rb
@@ -9,16 +9,15 @@ class FlatcamEvo < Formula
     depends_on "gdal"
     depends_on "geos"
     depends_on "pyqt"
+    depends_on "python-tk"
     depends_on "python@3.11"
-    depends_on "python-tk@3.11"
     depends_on "qpdf"
     depends_on "spatialindex"
   
     def install
-      venv = virtualenv_create(libexec, "python3.11", without_pip: false)
+      venv = virtualenv_create(libexec, "python3.11", without_pip:false)
       inreplace "flatcam.py", "\nimport sys", "#!#{libexec}/bin/python3\nimport sys"
       inreplace "requirements.txt", "numpy>=1.16", "numpy>=1.16, <2.0" # fix numpy 2.x issue(#31)
-      inreplace "requirements.txt", "gdal", "gdal < 3.12" # gdal 3.12 is not on brew (#38)
       system libexec/"bin/pip", "install",
                     "--no-binary", "pillow",# fix link breakage of libpng(#27)
                     "-r", "requirements.txt"


### PR DESCRIPTION
close #38 again

Pinning GDAL to 3.11 no longer works because 3.12 is released on homebrew. 

